### PR TITLE
Remove const specifiers for value parameters

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -27,8 +27,8 @@ system:
     // required, this must send a single CAN message with the given arbitration
     // ID (i.e. the CAN message ID) and data. The size will never be more than 8
     // bytes.
-    void send_can(const uint16_t arbitration_id, const uint8_t* data,
-            const uint8_t size) {
+    void send_can(uint16_t arbitration_id, const uint8_t* data,
+            uint8_t size) {
         ...
     }
 

--- a/src/isotp/receive.h
+++ b/src/isotp/receive.h
@@ -52,7 +52,7 @@ typedef struct {
  * when the message is completely sent.
  */
 IsoTpReceiveHandle isotp_receive(IsoTpShims* shims,
-        const uint32_t arbitration_id, IsoTpMessageReceivedHandler callback);
+        uint32_t arbitration_id, IsoTpMessageReceivedHandler callback);
 
 /* Public: Continue to receive a an ISO-TP message, based on a freshly
  * received CAN message.
@@ -76,8 +76,8 @@ IsoTpReceiveHandle isotp_receive(IsoTpShims* shims,
  * handle. Keep passing the same handle to this function when CAN frames arrive.
  */
 IsoTpMessage isotp_continue_receive(IsoTpShims* shims,
-        IsoTpReceiveHandle* handle, const uint32_t arbitration_id,
-        const uint8_t data[], const uint8_t size);
+        IsoTpReceiveHandle* handle, uint32_t arbitration_id,
+        const uint8_t data[], uint8_t size);
 
 #ifdef __cplusplus
 }

--- a/src/isotp/send.h
+++ b/src/isotp/send.h
@@ -46,7 +46,7 @@ typedef struct {
  *
  * Returns a message object to be passed to isotp_send()
  */
-IsoTpMessage isotp_new_send_message(const uint16_t arbitration_id, const uint8_t payload[], uint16_t size);
+IsoTpMessage isotp_new_send_message(uint16_t arbitration_id, const uint8_t payload[], uint16_t size);
 
 /* Public: Initiate sending a single ISO-TP message.
  *
@@ -88,8 +88,8 @@ IsoTpSendHandle isotp_send(IsoTpShims* shims, IsoTpMessage* message, IsoTpMessag
  *      it was successful.
  */
 bool isotp_receive_flowcontrol(IsoTpShims* shims, IsoTpSendHandle* handle,
-        const uint16_t arbitration_id, const uint8_t data[],
-        const uint8_t size);
+        uint16_t arbitration_id, const uint8_t data[],
+        uint8_t size);
 
 /* Public: Continue sending multi-frame package based on the current state
  *

--- a/tests/common.c
+++ b/tests/common.c
@@ -46,8 +46,8 @@ void debug(const char* format, ...) {
     va_end(args);
 }
 
-bool mock_send_can(const uint32_t arbitration_id, const uint8_t* data,
-        const uint8_t size) {
+bool mock_send_can(uint32_t arbitration_id, const uint8_t* data,
+        uint8_t size) {
     can_frame_was_sent = true;
     last_can_frame_sent_arb_id = arbitration_id;
     last_can_payload_size = size;
@@ -70,7 +70,7 @@ void message_received(const IsoTpMessage* message) {
     }
 }
 
-void message_sent(const IsoTpMessage* message, const bool success) {
+void message_sent(const IsoTpMessage* message, bool success) {
     if(success) {
         debug("Sent ISO-TP message:");
     } else {
@@ -88,8 +88,9 @@ void message_sent(const IsoTpMessage* message, const bool success) {
     }
 }
 
-void can_frame_sent(const uint32_t arbitration_id, const uint8_t* payload,
-        const uint8_t size) {
+void can_frame_sent(uint32_t arbitration_id, const uint8_t* payload,
+        uint8_t size) {
+    (void)payload;
     debug("Sent CAN Frame with arb ID 0x%x and %d bytes", arbitration_id, size);
 }
 


### PR DESCRIPTION
clang-tidy doesn't like this construct, and gives the following warning:
readability-avoid-const-params-in-decls
https://clang.llvm.org/extra/clang-tidy/checks/readability-avoid-const-params-in-decls.html